### PR TITLE
check_runtime_status field for controller description

### DIFF
--- a/msg/ConfigurationComponent.msg
+++ b/msg/ConfigurationComponent.msg
@@ -3,4 +3,5 @@ string state
 string type
 string[] hardware_interfaces
 string[] controllers
+bool[] check_runtime_status
 bool   hidden


### PR DESCRIPTION
The field 'check_runtime_status' further field has been added to the msg.
The 'check_runtime_status' is used to preserve backcompatibility between cnr_ros_controllers and itia_ros_controllers'
if 'check_runtime_status' is set to false, a generic controller inherited from controller_interface::Controller<T> can be loaded. The configuration manager, indeed, will not check the status of the controller.

However, if it is set to 'false', The shutdown of the controller is not guaranteed safe (i.e., the configuration cannot know if the controller is expired before to destroy the robot_hw interface)
